### PR TITLE
fix: replace deprecated `Squiz.WhiteSpace.LanguageConstructSpacing`

### DIFF
--- a/src/GEWISPHPCodingStandards/ruleset.xml
+++ b/src/GEWISPHPCodingStandards/ruleset.xml
@@ -761,7 +761,7 @@
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing" />
 
     <!-- Require space after language constructs -->
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing" />
 
     <!-- Require space around logical operators -->
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing" />


### PR DESCRIPTION
# Description
Changes `Squiz.WhiteSpace.LanguageConstructSpacing` for `Generic.WhiteSpace.LanguageConstructSpacing`

## Related issues/external references
https://github.com/squizlabs/PHP_CodeSniffer/issues/1953

## Types of changes
- Dependency update
- Breaking change: any exclusions for rule `Squiz.WhiteSpace.LanguageConstructSpacing` must be updated to `Generic.WhiteSpace.LanguageConstructSpacing`. None in `gewisweb:main` or `gewisdb:main`.